### PR TITLE
Unfaithful generation in  large graphs

### DIFF
--- a/causally/graph/random_graph.py
+++ b/causally/graph/random_graph.py
@@ -4,6 +4,8 @@ import numpy as np
 import networkx as nx
 from abc import ABCMeta, abstractmethod
 
+from numpy.core.multiarray import array as array
+
 from causally.utils.graph import max_edges_in_dag
 
 
@@ -54,13 +56,13 @@ class GaussianRandomPartition(GraphGenerator):
 
     Parameters
     ----------
-    num_nodes : int
+    num_nodes: int
         Number of nodes.
-    p_in : float
+    p_in: float
         Probability of edge connection with nodes in the cluster.
-    p_out : float
+    p_out: float
         Probability of edge connection with nodes in different clusters.
-    n_clusters : int
+    n_clusters: int
         Number of clusters in the graph.
     min_cluster_size: int, default 2
         Minimum number of elements for each cluster.
@@ -133,9 +135,9 @@ class GaussianRandomPartition(GraphGenerator):
 
         Parameters
         ----------
-        A : np.array
+        A: np.array
             Current adjacency matrix
-        c_size : int
+        c_size: int
             Size of the cluster to generate
         """
         # Join the graphs by block matrices
@@ -166,11 +168,11 @@ class ErdosRenyi(GraphGenerator):
 
     Parameters
     ----------
-    num_nodes : int
+    num_nodes: int
         Number of nodes.
-    expected_degree : int, default is None
+    expected_degree: int, default is None
         Expected degree of each node.
-    p_edge : float, default is None
+    p_edge: float, default is None
         Probability of edge between each pair of nodes.
     min_num_edges: int, default 2
         The minimum number of edges required in the graph.
@@ -246,9 +248,9 @@ class BarabasiAlbert(GraphGenerator):
 
     Parameters
     ----------
-    num_nodes : int
+    num_nodes: int
         Number of nodes.
-    expected_degree : int
+    expected_degree: int
         Expected degree of each node.
     preferential_attachment_out: bool, default True
         Select the preferential attachment strategy. If True,
@@ -297,6 +299,29 @@ class BarabasiAlbert(GraphGenerator):
         # Permute to avoid trivial ordering
         A = self._make_random_order(A)
         return A
+
+
+class CustomGraph(GraphGenerator):
+    """Generator of user-specified, deterministic, graphs
+
+    Parameters
+    ----------
+    adjacency: np.array
+        Adjacency matrix representation of a directed graph
+        The presence of directed edge from node ``i`` to node ``j``
+        is denoted by ``A[i, j] = 1``. Absence of edges is denote by 0.
+
+    """
+
+    def __init__(self, adjacency: np.array):
+        num_nodes = len(adjacency)
+        super().__init__(num_nodes)
+        self.adjacency = adjacency
+
+    def get_random_graph(self) -> np.array:
+        """Return the adjacency provided as input to the constructor method.
+        """
+        return self.adjacency
 
 
 # ********************** #

--- a/causally/scm/causal_mechanism.py
+++ b/causally/scm/causal_mechanism.py
@@ -124,7 +124,7 @@ class NeuralNetMechanism(PredictionModel):
 
         Parameters
         ----------
-        X : np.array of shape (num_samples, num_parents)
+        X: np.array of shape (num_samples, num_parents)
             Input of the neural network with the parent node instances.
 
         Returns
@@ -181,7 +181,7 @@ class GaussianProcessMechanism(PredictionModel):
 
     Parameters
     ----------
-    gamma : float, default 1
+    gamma: float, default 1
         The gamma parameters fixing the variance of the kernel.
         Larger values of gamma determines bigger magnitude of the causal mechanisms.
     """
@@ -197,7 +197,7 @@ class GaussianProcessMechanism(PredictionModel):
 
         Parameters
         ----------
-        X : np.array of shape (num_samples, num_parents)
+        X: np.array of shape (num_samples, num_parents)
             Input of the RBF kernel.
 
         Returns

--- a/causally/scm/causal_mechanism.py
+++ b/causally/scm/causal_mechanism.py
@@ -62,10 +62,7 @@ class LinearMechanism(PredictionModel):
             The output of the causal mechanism
         """
         if X.ndim != 2:
-            raise ValueError(
-                f"Number of dimensions {X.ndim} different from 2."
-                " If input has 1 dimension, consider reshaping it with reshape(-1, 1)"
-            )
+            X = X.reshape((-1, 1))
         n_covariates = X.shape[1]
 
         # Random initialization of the causal mechanism
@@ -135,6 +132,8 @@ class NeuralNetMechanism(PredictionModel):
         effect: np.array of shape (num_samples)
             The output of the neural network with X as input.
         """
+        if X.ndim != 2:
+            X = X.reshape((-1, 1))
         n_samples = X.shape[0]
         n_causes = X.shape[1]
 

--- a/causally/scm/causal_mechanism.py
+++ b/causally/scm/causal_mechanism.py
@@ -20,12 +20,12 @@ class LinearMechanism(PredictionModel):
     Parameters
     ----------
     min_weight: float, default -1
-        Minimum value of causal mechanisms weights
+        Minimum value for the coefficients of the linear mechanisms.
     max_weight: float, default 1
-        Maximum value of causal mechanisms weights
+        Maximum value for the coefficients of the linear mechanisms.
     min_abs_weight: float, default 0.05
-        Minimum value of the absolute value of any causal mechanism weight.
-        Low value of min_abs_weight potentially lead to lambda-unfaithful distributions.
+        Smallest allowed absolute value of any linear mechanism coefficient.
+        Low value of ``min_abs_weight`` potentially lead to lambda-unfaithful distributions.
     """
 
     def __init__(
@@ -49,17 +49,25 @@ class LinearMechanism(PredictionModel):
         self.linear_reg = LinearRegression(fit_intercept=False)
 
     def predict(self, X: np.array) -> np.array:
-        """Transform X via a linear causal mechanism.
+        """Apply a linera transformation on X.
+
+        Given a vector ``x`` with :math:`p` features, the output ``y`` is given by:
+
+        .. math::
+
+                y = \sum_{i=1}^p \\alpha_i x_i
+
+        where :math:`\\alpha_i` are random coefficients.
 
         Parameters
         ----------
-        X: np.array of shape (num_samples, num_parents)
-            Samples of the parents to be transformed by the causal mechanism.
+        X: np.array, shape (num_samples, num_parents)
+            Parents' observtations to be transformed by the causal mechanism.
 
         Returns
         -------
-        y: np.array
-            The output of the causal mechanism
+        y:  np.array, shape (num_samples)
+            The output of the causal mechanism.
         """
         if X.ndim != 2:
             X = X.reshape((-1, 1))
@@ -94,10 +102,10 @@ class NeuralNetMechanism(PredictionModel):
     ----------
     weights_mean: float, default 0
         Average value of the initialized weights.
-    weights_std: float, default 0
+    weights_std: float, default 1
         Standard deviation of the initialized weights.
     hidden_dim: int, default 10
-        Number of neurons in the hidden layer
+        Number of neurons in the hidden layer.
     activation: nn.Module, default ``nn.PReLU``
         The nonlinear activation function.
     """
@@ -117,19 +125,19 @@ class NeuralNetMechanism(PredictionModel):
         self._model = None
 
     def predict(self, X: np.array) -> np.array:
-        """Generate the effect given the parents.
+        """Generate the effect given the observations of the parent nodes.
 
-        The effect is generated as a nonlinear function parametrized by a neural network
+        The effect is generated as a nonlinear transformation parametrized by a neural network
         with a single hidden layer.
 
         Parameters
         ----------
-        X: np.array of shape (num_samples, num_parents)
-            Input of the neural network with the parent node instances.
+        X: np.array, shape (num_samples, num_parents)
+            Parents' observtations to be transformed by the causal mechanism.
 
         Returns
         -------
-        effect: np.array of shape (num_samples)
+        y: np.array, shape (num_samples)
             The output of the neural network with X as input.
         """
         if X.ndim != 2:
@@ -156,7 +164,7 @@ class NeuralNetMechanism(PredictionModel):
         return effect.numpy()
 
     def _weight_init(self, module):
-        """Random initialization of model weights."""
+        """Random initialization of the model's weights."""
         if isinstance(module, nn.Linear):
             nn.init.normal_(
                 module.weight.data, mean=self.weights_mean, std=self.weights_std
@@ -164,7 +172,7 @@ class NeuralNetMechanism(PredictionModel):
 
     @property
     def model(self):
-        """Return the nn.Module instance of the neural network architecture."""
+        """nn.Module instance of the neural network architecture."""
         if self._model is None:
             raise ValueError(
                 "Torch model not initialized. Call ``self.predict()`` first"
@@ -173,10 +181,10 @@ class NeuralNetMechanism(PredictionModel):
 
 
 class GaussianProcessMechanism(PredictionModel):
-    """Nonlinear causal mechanism sampled from a gaussian process.
+    """Nonlinear causal mechanism sampled from a Gaussian process.
 
     The nonlinear transformation is generated sampling the effect from a
-    gaussian process with covariance matrix defined as the kernel matrix of the
+    Gaussian process with covariance matrix defined as the kernel matrix of the
     parents' observations.
 
     Parameters
@@ -190,19 +198,19 @@ class GaussianProcessMechanism(PredictionModel):
         self.rbf = PairwiseKernel(gamma=gamma, metric="rbf")
 
     def predict(self, X: np.array) -> np.array:
-        """Generate the effect given the parents.
+        """Generate the effect given the observations of the parent nodes.
 
         The effect is generated as a nonlinear function sampled from a
         gaussian process.
 
         Parameters
         ----------
-        X: np.array of shape (num_samples, num_parents)
+        X: np.array, shape (num_samples, num_parents)
             Input of the RBF kernel.
 
         Returns
         -------
-        effect: np.array of shape (num_samples)
+        y: np.array, shape (num_samples)
             Causal effect sampled from the gaussian process with
             covariance matrix given by the RBF kernel with X as input.
         """
@@ -218,23 +226,23 @@ class GaussianProcessMechanism(PredictionModel):
 
 # Base class for PostnonLinearModel invertible functions
 class InvertibleFunction:
-    """Invertible functions for the post-nonlinear model abstract class.
+    """Base class for defining invertible functions for the post-nonlinear model.
 
     This class can be used to define the invertible transformation for the
     structural equations of a PostNonlinear model. In order to instantiate
-    an InvertibleFunction, simply pass
+    an InvertibleFunction, simply provide the desired transformation as a Python Callable.
 
     Parameters
     ----------
     function: Callable
-        Python function implementing an invertible mathematical transformation.
+        Function implementing an invertible map.
     """
 
     def __init__(self, function: Callable) -> None:
         self.function = function
 
     def forward(self, input: np.array):
-        """Apply the invertible function to the input."""
+        """Apply the invertible map to the input."""
         return self.function(input)
 
     def __call__(self, input: np.array):

--- a/causally/scm/context.py
+++ b/causally/scm/context.py
@@ -53,10 +53,10 @@ class SCMContext:
         """Make the assumption of model with time lagged autoregressive effects.
 
         Structural equations take the following autoregressive form:
-        
-        .. math:: 
-        
-                X_i(t):= f_i(\operatorname{PA}_i(t)) + N_i + \sum_{k=t-\operatorname{order}} \\alpha(k)*X_i(k)
+
+        .. math::
+
+                X_i(t):= f_i(\operatorname{PA}_i(t)) + N_i + \sum_{k=t-\operatorname{order}} \\alpha(k) X_i(k)
 
         where :math:`f_i` is the nonlinear causal mechanism,
         :math:`N_i` is the noise term of the structural equation,
@@ -137,7 +137,6 @@ class SCMContext:
             )
         return self._autoregressive_order
 
-
     @property
     def confounded_adjacency(self):
         if self._confounded_adjacency is None:
@@ -147,7 +146,7 @@ class SCMContext:
                 + " `sample` method of the BaseStructuralCausalModel class"
             )
         return self._confounded_adjacency
-    
+
     @confounded_adjacency.setter
     def confounded_adjacency(self, A):
         self._confounded_adjacency = A
@@ -161,7 +160,7 @@ class SCMContext:
                 + " `sample` method of the BaseStructuralCausalModel class"
             )
         return self._unfaithful_adjacency
-    
+
     @unfaithful_adjacency.setter
     def unfaithful_adjacency(self, A):
         self._unfaithful_adjacency = A

--- a/causally/scm/context.py
+++ b/causally/scm/context.py
@@ -102,8 +102,8 @@ class SCMContext:
     def measure_err_model(self, gamma: float):
         """Make the assumption of model with measurement error.
 
-        Rather than observing perfectly measure random variables :math:`x_i`
-        in the dataset (where :math:`i` is the index of a node), we observe
+        Rather than observing perfectly measured random variables :math:`x_i`
+        (where :math:`i` is the index of a node), in the dataset we observe
         :math:`\\tilde{x}_i := x_i + \epsilon_i`, where :math:`\epsilon_i` is
         a Gaussian random variable centered at zero, whose variance is parametrized
         by the inverse signal to noise ratio

--- a/causally/scm/context.py
+++ b/causally/scm/context.py
@@ -6,6 +6,10 @@ class SCMContext:
         self._measure_error_gamma = None
         self.assumptions = list()
 
+        # Stateful information about violations
+        self._confounded_adjacency = None
+        self._unfaithful_adjacency = None
+
     def confounded_model(self, p_confounder: float):
         """Make the assumption of model with latent confounders.
 
@@ -132,3 +136,32 @@ class SCMContext:
                 + " ``autoregressive_model``."
             )
         return self._autoregressive_order
+
+
+    @property
+    def confounded_adjacency(self):
+        if self._confounded_adjacency is None:
+            raise AttributeError(
+                "confounded_adjacency is None. "
+                + " The confounded adjacency matrix is created in the"
+                + " `sample` method of the BaseStructuralCausalModel class"
+            )
+        return self._confounded_adjacency
+    
+    @confounded_adjacency.setter
+    def confounded_adjacency(self, A):
+        self._confounded_adjacency = A
+
+    @property
+    def unfaithful_adjacency(self):
+        if self._unfaithful_adjacency is None:
+            raise AttributeError(
+                "unfaithful_adjacency is None. "
+                + " The unfaithful adjacency matrix is created in the"
+                + " `sample` method of the BaseStructuralCausalModel class"
+            )
+        return self._unfaithful_adjacency
+    
+    @unfaithful_adjacency.setter
+    def unfaithful_adjacency(self, A):
+        self._unfaithful_adjacency = A

--- a/causally/scm/noise.py
+++ b/causally/scm/noise.py
@@ -15,10 +15,12 @@ class Distribution(metaclass=ABCMeta):
 
 
 class RandomNoiseDistribution(Distribution, metaclass=ABCMeta):
-    """Base class for custom generation of random distributions.
+    """Base abstract class for sampling from non-parametric, randomly generated, distributions.
 
     Samples from the random distribution are generated as nonlinear transformations
-    of samples form a standard normal.
+    of samples form a standard normal. Classes inheriting from ``RandomNoiseDistribution``
+    must implement the ``_forward`` method, which defines the nonlinear transformation
+    that is applied to a standard normal sample.
     """
 
     def __init__(self, standardize: bool = False) -> None:
@@ -35,7 +37,7 @@ class RandomNoiseDistribution(Distribution, metaclass=ABCMeta):
 
         Returns
         -------
-        noise: np.array of shape (num_samples, num_nodes)
+        noise: np.array, shape (num_samples, num_nodes)
             Sample a random vector of noise terms.
         standardize: bool, default False
             If True, remove empirical mean and normalize deviation to one.
@@ -69,7 +71,7 @@ class RandomNoiseDistribution(Distribution, metaclass=ABCMeta):
 
 # *** Wrappers of numpy distributions *** #
 class Normal(Distribution):
-    """Wrapper for np.random.normal() sampler.
+    """Wrapper for ``numpy.random.normal()`` sampler.
 
     Parameters
     ----------
@@ -102,12 +104,12 @@ class Normal(Distribution):
 
 
 class Exponential(Distribution):
-    r"""Wrapper for np.random.exponential() sampler.
+    r"""Wrapper for ``numpy.random.exponential()`` sampler.
 
     Parameters
     ----------
     scale: Union[float, np.array of floats], default 1
-        The scale parameter:math:`\beta = \frac{1}{\lambda}`, must be non-negative.
+        The scale parameter :math:`\beta = \frac{1}{\lambda}`, must be non-negative.
     """
 
     def __init__(self, scale: Union[float, np.array] = 1.0):
@@ -130,18 +132,16 @@ class Exponential(Distribution):
 
 
 class Uniform(Distribution):
-    r"""Wrapper for np.random.uniform() sampler.
+    r"""Wrapper for ``numpy.random.uniform()`` sampler.
 
     Parameters
     ----------
     low: Union[float, np.array of floats], default 0
-        Lower boundary of the output interval. All values generated will be greater than
-        or equal to low. The default value is 0.
+        Lower bound of the output interval. All values generated will be greater than
+        or equal to ``low``.
     high: Union[float, np.array of floats], default 1
-        Upper boundary of the output interval. All values generated will be less than or
-        equal to high. The high limit may be included in the returned array of floats due
-        to floating-point rounding in the equation ``low + (high-low) * random_sample()``.
-        The default value is 1.0.
+        Upper bound of the output interval. All values generated will be less than or
+        equal to ``high``.
     """
 
     def __init__(
@@ -168,17 +168,17 @@ class Uniform(Distribution):
 
 # *** MLP transformation of standard normal *** #
 class MLPNoise(RandomNoiseDistribution):
-    """Neural network to generate samples as transformation of a standard normal.
+    """Samples form adistribution defined by a neural network applied to a standard normal.
 
     Generate a random variable with unknown distribution as a nonlinear transformation of
     a standard Gaussian. The transformation is parametrized by a simple neural network
-    with one hidden layer and nonlinear activations.
+    with one hidden layer and a nonlinear activation.
 
     Parameters
     ----------
     hidden_dim: int, default 100
         Number of neurons in the hidden layer.
-    activation: nn.Module, default ``nn.Sigmoid``
+    activation: nn.Module, default nn.Sigmoid
         The nonlinear activation function.
     bias: bool, default True
         If True, include the bias term.
@@ -191,8 +191,7 @@ class MLPNoise(RandomNoiseDistribution):
     b_bias: float, default 1
         Upper bound for the value of the model bias terms.
     standardize: bool, default False
-        If True, remove the empirical mean and variance from the transformed
-        random variable.
+        If True, remove the empirical mean and variance of the samples.
     """
 
     def __init__(

--- a/causally/scm/noise.py
+++ b/causally/scm/noise.py
@@ -35,9 +35,9 @@ class RandomNoiseDistribution(Distribution, metaclass=ABCMeta):
 
         Returns
         -------
-        noise : np.array of shape (num_samples, num_nodes)
+        noise: np.array of shape (num_samples, num_nodes)
             Sample a random vector of noise terms.
-        standardize : bool, default False
+        standardize: bool, default False
             If True, remove empirical mean and normalize deviation to one.
         """
         # Sample from standard normal
@@ -107,7 +107,7 @@ class Exponential(Distribution):
     Parameters
     ----------
     scale: Union[float, np.array of floats], default 1
-        The scale parameter :math:`\beta = \frac{1}{\lambda}`, must be non-negative.
+        The scale parameter:math:`\beta = \frac{1}{\lambda}`, must be non-negative.
     """
 
     def __init__(self, scale: Union[float, np.array] = 1.0):

--- a/causally/scm/scm.py
+++ b/causally/scm/scm.py
@@ -88,10 +88,11 @@ class BaseStructuralCausalModel(metaclass=ABCMeta):
         """
         adjacency = self.adjacency.copy()
 
-        # Pre-process: graph misspecification
-
+        # Pre-process for graph misspecification
         # NOTE: Unfaithful before confounded to avoid cancelling on confounders matrix
         if "unfaithful" in list(self.scm_context.assumptions):
+            child_p1_effects = dict()  # key: child, value: sum of p1 values
+            child_linear_parents = dict() # key: child, value: list of p2 parents with linear effects
             p_unfaithful = self.scm_context.p_unfaithful
             (
                 adjacency,
@@ -105,10 +106,12 @@ class BaseStructuralCausalModel(metaclass=ABCMeta):
 
         # Sample the noise
         noise = self.noise_generator.sample((self.num_samples, len(adjacency)))
-        X = noise.copy()
+        # X = noise.copy() # NO! Noise is handled by the mechanisms!
+        X = np.zeros(noise.shape)
 
         # Generate the data starting from source nodes
-        for i in topological_order(adjacency):
+        graph_order = topological_order(adjacency)
+        for i in graph_order:
             parents = np.nonzero(adjacency[:, i])[0]
             if len(np.nonzero(adjacency[:, i])[0]) > 0:
                 X[:, i] = self._sample_mechanism(X[:, parents], noise[:, i])
@@ -118,15 +121,20 @@ class BaseStructuralCausalModel(metaclass=ABCMeta):
                     order = self.scm_context.autoregressive_order
                     X[:, i] = _AutoregressiveMixin.add_time_lag(X[:, i], order)
 
-        # Post-process: data misspecification
+                # Unfaithful path canceling
+                if "unfaithful" in list(self.scm_context.assumptions):
+                    X[:, i] = _UnfaithfulMixin.generate_variable(
+                        X, i, noise[:, i], parents, unfaithful_triplets_order, \
+                        self._sample_mechanism, child_p1_effects, child_linear_parents
+                    )
+
+        # Post-process for data misspecification
         if "measurement error" in list(self.scm_context.assumptions):
             gamma = self.scm_context.measure_error_gamma
             X = _MeasurementErrorMixin.add_measure_error(X, gamma)
         if "confounded" in list(self.scm_context.assumptions):
             d, _ = self.adjacency.shape
             X = _ConfoundedMixin.confound_dataset(X, n_confounders=d)
-        if "unfaithful" in list(self.scm_context.assumptions):
-            X = _UnfaithfulMixin.unfaithful_dataset(X, noise, unfaithful_triplets_order)
 
         return X, self.adjacency
 

--- a/causally/scm/scm.py
+++ b/causally/scm/scm.py
@@ -90,17 +90,18 @@ class BaseStructuralCausalModel(metaclass=ABCMeta):
 
         # Pre-process: graph misspecification
 
-        # TODO: add constraints
-        # i.e. unfaithful must be before confounded to avoid cancelling occurring on confounders matrix
+        # NOTE: Unfaithful before confounded to avoid cancelling on confounders matrix
         if "unfaithful" in list(self.scm_context.assumptions):
             p_unfaithful = self.scm_context.p_unfaithful
             (
                 adjacency,
                 unfaithful_triplets_order,
             ) = _UnfaithfulMixin.unfaithful_adjacency(adjacency, p_unfaithful)
+            self.scm_context.unfaithful_adjacency = adjacency
         if "confounded" in list(self.scm_context.assumptions):
             p_confounder = self.scm_context.p_confounder
             adjacency = _ConfoundedMixin.confound_adjacency(adjacency, p_confounder)
+            self.scm_context.confounded_adjacency = adjacency
 
         # Sample the noise
         noise = self.noise_generator.sample((self.num_samples, len(adjacency)))

--- a/causally/scm/scm_property.py
+++ b/causally/scm/scm_property.py
@@ -16,15 +16,15 @@ class _ConfoundedMixin:
 
         Parameters
         ----------
-        adjacency: np.array of shape (num_nodes x num_nodes)
+        adjacency: np.array, shape (num_nodes x num_nodes)
             The adjacency matrix without latent confounders.
         p_confounder: float
             The probability of adding a latent common cause between a pair of nodes,
-            sampled as a Bernoulli random variable.
+            parametrizing a Bernoulli random variable.
 
         Returns
         -------
-        confounded_adj: np.array of shape (2*num_nodes, 2*num_nodes)
+        confounded_adj: np.array, shape (2*num_nodes, 2*num_nodes)
             The adjacency matrix with additional latent confounders.
         """
         num_nodes, _ = adjacency.shape
@@ -55,7 +55,7 @@ class _ConfoundedMixin:
 
         Parameters
         ----------
-        X: np.array of shape (num_samples, 2*num_nodes)
+        X: np.array, shape (num_samples, 2*num_nodes)
             The dataset with latent confoudners observations. The columns
             corresponding to confounders' observations are the first ``n_confounders``.
         n_confounders: int
@@ -63,7 +63,7 @@ class _ConfoundedMixin:
 
         Returns
         -------
-        X: np.array of shape (num_samples, num_nodes)
+        X: np.array, shape (num_samples, num_nodes)
             The dataset without latent confounders' observations' columns.
         """
         X = X[:, n_confounders:]
@@ -79,14 +79,14 @@ class _MeasurementErrorMixin:
 
         Parameters
         ----------
-        X: np.array of shape (num_samples, num_nodes)
+        X: np.array, shape (num_samples, num_nodes)
             The input dataset without measurement errors
         gamma: Union[float, List[float]]
             The inverse signal to noise ratio
 
         Returns
         -------
-        X: np.array of shape (num_samples, num_nodes)
+        X: np.array, shape (num_samples, num_nodes)
             The input dataset with measurement error sampled from a zero
             centered gaussian with variance
 
@@ -122,11 +122,11 @@ class _UnfaithfulMixin:
 
         Parameters
         ----------
-        X: np.array of shape (num_samples, num_nodes)
+        X: np.array, shape (num_samples, num_nodes)
             The input dataset without measurement errors.
         node: int
             Index of the random variable to generate.
-        node_noise: np.array of shape (num_samples, )
+        node_noise: np.array, shape (num_samples, )
             Noise observations of the random variable to generate.
         parents: np.array
             List with the indices of the node's parents random variables,
@@ -147,7 +147,7 @@ class _UnfaithfulMixin:
 
         Returns
         -------
-        total_effect: np.array of shape (num_samples)
+        total_effect: np.array, shape (num_samples)
             The observations of the node random variable.
         """
         p2_p1_parents = dict()  # key: p2, value: list of the p1 parents additive on p2
@@ -207,7 +207,7 @@ class _UnfaithfulMixin:
 
         Parameters
         ----------
-        adjacency: np.array of shape (num_nodes, num_nodes)
+        adjacency: np.array, shape (num_nodes, num_nodes)
             The input adjacency matrix faithful to the data distribution.
         p_unfaithful: float
             Probability of  unfaitfhul conditional independence in the presence of
@@ -263,7 +263,7 @@ class _AutoregressiveMixin:
 
         Parameters
         ----------
-        X: np.array of shape (num_samples)
+        X: np.array, shape (num_samples)
             Observations of a random node.
         order: int
             The number of time lags
@@ -274,7 +274,7 @@ class _AutoregressiveMixin:
 
         Returns
         -------
-        X: np.array of shape (num_samples)
+        X: np.array, shape (num_samples)
             Observations of a random node with addition of the time lagged effects.
         """
         if len(X) <= order:

--- a/causally/tests/test_scm_property.py
+++ b/causally/tests/test_scm_property.py
@@ -2,10 +2,12 @@ import numpy as np
 import random
 
 from causally.graph.random_graph import ErdosRenyi
+from causally.scm.noise import Normal
+from causally.scm.scm import AdditiveNoiseModel
+from causally.scm.context import SCMContext
+from causally.scm.causal_mechanism import NeuralNetMechanism
 from causally.scm.scm_property import (
-    _ConfoundedMixin,
     _MeasurementErrorMixin,
-    _UnfaithfulMixin,
     _AutoregressiveMixin,
 )
 
@@ -16,8 +18,18 @@ random.seed(SEED)
 
 ###################### Test unfaithful model ######################
 def test_given_fully_connected_matrix_when_model_unfaithful_then_path_cancelling_in_moral_triplets():
-    adjacency = np.triu(np.ones((5, 5)), k=1)
-    unfaithful_adj, _ = _UnfaithfulMixin.unfaithful_adjacency(adjacency, p_unfaithful=1)
+    p_unfaithful=1
+    num_nodes = 5
+    p_edge = 1
+    graph_generator = ErdosRenyi(num_nodes, p_edge=p_edge)
+    noise_generator = Normal(0, 1)
+    mechanism = NeuralNetMechanism()
+    context = SCMContext()
+    context.unfaithful_model(p_unfaithful)
+    scm = AdditiveNoiseModel(10, graph_generator, noise_generator, mechanism, context)
+
+    _, _ = scm.sample() # sampling creates the unfaithful adjacency
+    unfaithful_adj = scm.scm_context.unfaithful_adjacency
 
     target_adj = np.array(
         [
@@ -32,12 +44,18 @@ def test_given_fully_connected_matrix_when_model_unfaithful_then_path_cancelling
 
 
 def test_given_adj_when_p_unfaithful_0_then_adjacency_and_unfaithful_adjacency_are_equal():
-    p_unfaithful = 0.0
+    p_unfaithful = 0.001
     num_nodes = 20
     p_edge = 1
     graph_generator = ErdosRenyi(num_nodes, p_edge=p_edge)
-    adjacency = graph_generator.get_random_graph()
-    unfaithful_adj, _ = _UnfaithfulMixin.unfaithful_adjacency(adjacency, p_unfaithful)
+    noise_generator = Normal(0, 1)
+    mechanism = NeuralNetMechanism()
+    context = SCMContext()
+    context.unfaithful_model(p_unfaithful)
+    scm = AdditiveNoiseModel(10, graph_generator, noise_generator, mechanism, context)
+
+    _, adjacency = scm.sample() # sampling creates the unfaithful adjacency
+    unfaithful_adj = scm.scm_context.unfaithful_adjacency
     assert np.allclose(adjacency, unfaithful_adj, 0.00001)
 
 
@@ -47,11 +65,17 @@ def test_given_p_confounded_when_generating_graphs_then_rate_of_confounded_pairs
     num_nodes = 20
     p_edge = 0.4
     graph_generator = ErdosRenyi(num_nodes, p_edge=p_edge)
+    noise_generator = Normal(0, 1)
+    mechanism = NeuralNetMechanism()
+    context = SCMContext()
+    context.confounded_model(p_confounder)
 
     # sum_confounded_pairs = 0
     for _ in range(10):
-        adjacency = graph_generator.get_random_graph()
-        confounded_adj = _ConfoundedMixin.confound_adjacency(adjacency, p_confounder)
+        scm = AdditiveNoiseModel(10, graph_generator, noise_generator, mechanism, context)
+
+        _, _ = scm.sample() # sampling creates the confounded adjacency
+        confounded_adj = scm.scm_context.confounded_adjacency
         confounders_matrix = confounded_adj[num_nodes:, num_nodes:]
         n_direct_confounders = 0
         for confounder in range(num_nodes):
@@ -65,12 +89,17 @@ def test_given_p_confounded_when_generating_graphs_then_rate_of_confounded_pairs
 
 
 def test_given_p_confounded_0_then_confounders_matrix_empty():
-    p_confounder = 0.0
+    p_confounder = 0.001
     num_nodes = 20
     p_edge = 0.4
     graph_generator = ErdosRenyi(num_nodes, p_edge=p_edge)
-    adjacency = graph_generator.get_random_graph()
-    confounded_adj = _ConfoundedMixin.confound_adjacency(adjacency, p_confounder)
+    noise_generator = Normal(0, 1)
+    mechanism = NeuralNetMechanism()
+    context = SCMContext()
+    context.confounded_model(p_confounder)
+    scm = AdditiveNoiseModel(10, graph_generator, noise_generator, mechanism, context)
+    _, _ = scm.sample() # sampling creates the confounded adjacency
+    confounded_adj = scm.scm_context.confounded_adjacency
     assert np.sum(confounded_adj[:, :num_nodes]) == 0
 
 

--- a/causally/tests/test_scm_property.py
+++ b/causally/tests/test_scm_property.py
@@ -1,11 +1,12 @@
-import numpy as np
 import random
+import pytest
+import numpy as np
 
-from causally.graph.random_graph import ErdosRenyi
-from causally.scm.noise import Normal
+from causally.graph.random_graph import ErdosRenyi, CustomGraph
+from causally.scm.noise import Normal, Uniform
 from causally.scm.scm import AdditiveNoiseModel
 from causally.scm.context import SCMContext
-from causally.scm.causal_mechanism import NeuralNetMechanism
+from causally.scm.causal_mechanism import NeuralNetMechanism, LinearMechanism
 from causally.scm.scm_property import (
     _MeasurementErrorMixin,
     _AutoregressiveMixin,
@@ -16,35 +17,83 @@ np.random.seed(SEED)
 random.seed(SEED)
 
 
+@pytest.fixture
+def custom_adj():
+    # Directed acyclic graph maximally dense
+    return np.array(
+        [
+            [0, 1, 1, 0, 1],
+            [0, 0, 0, 0, 0],
+            [0, 1, 0, 0, 1],
+            [1, 1, 1, 0, 1],
+            [0, 1, 0, 0, 0],
+        ]
+    )
+
+
 ###################### Test unfaithful model ######################
-def test_given_fully_connected_matrix_when_model_unfaithful_then_path_cancelling_in_moral_triplets():
-    p_unfaithful=1
+def test_given_unfaithful_model_when_generating_data_then_path_cancelling_is_observed(
+    custom_adj,
+):
+    graph_generator = CustomGraph(custom_adj)
+    noise_generator = Uniform(1, 1)
+    causal_mechanism = LinearMechanism(min_weight=1, max_weight=1)
+
+    # Make assumption: unfaithful model
+    context = SCMContext()
+    context.unfaithful_model(p_unfaithful=1)
+
+    # Generate the data
+    model = AdditiveNoiseModel(
+        num_samples=100,
+        graph_generator=graph_generator,
+        noise_generator=noise_generator,
+        causal_mechanism=causal_mechanism,
+        scm_context=context,
+        seed=42,
+    )
+
+    # Sample from the model
+    dataset, _ = model.sample()
+    assert np.allclose(
+        dataset.mean(axis=0), np.array([2.0, 0.0, 4.0, 1.0, 0.0]), 0.0005
+    )
+    assert np.allclose(dataset.std(axis=0), np.array([0.0, 0.0, 0.0, 0.0, 0.0]), 0.0005)
+
+
+def test_given_fully_connected_matrix_when_model_unfaithful_then_path_cancelling_in_moral_triplets(
+    custom_adj,
+):
+    p_unfaithful = 1
     num_nodes = 5
     p_edge = 1
-    graph_generator = ErdosRenyi(num_nodes, p_edge=p_edge)
+    num_samples = 2
+    graph_generator = CustomGraph(custom_adj)
     noise_generator = Normal(0, 1)
     mechanism = NeuralNetMechanism()
     context = SCMContext()
     context.unfaithful_model(p_unfaithful)
-    scm = AdditiveNoiseModel(10, graph_generator, noise_generator, mechanism, context)
+    scm = AdditiveNoiseModel(
+        num_samples, graph_generator, noise_generator, mechanism, context
+    )
 
-    _, _ = scm.sample() # sampling creates the unfaithful adjacency
+    _, _ = scm.sample()  # sampling creates the unfaithful adjacency
     unfaithful_adj = scm.scm_context.unfaithful_adjacency
 
     target_adj = np.array(
         [
-            [0, 1, 0, 0, 0],
-            [0, 0, 1, 1, 1],
-            [0, 0, 0, 1, 0],
-            [0, 0, 0, 0, 1],
+            [0, 0, 1, 0, 0],
             [0, 0, 0, 0, 0],
+            [0, 1, 0, 0, 1],
+            [1, 0, 1, 0, 0],
+            [0, 1, 0, 0, 0],
         ]
     )
     assert np.allclose(unfaithful_adj, target_adj)
 
 
 def test_given_adj_when_p_unfaithful_0_then_adjacency_and_unfaithful_adjacency_are_equal():
-    p_unfaithful = 0.001
+    p_unfaithful = 1e-9
     num_nodes = 20
     p_edge = 1
     graph_generator = ErdosRenyi(num_nodes, p_edge=p_edge)
@@ -52,11 +101,11 @@ def test_given_adj_when_p_unfaithful_0_then_adjacency_and_unfaithful_adjacency_a
     mechanism = NeuralNetMechanism()
     context = SCMContext()
     context.unfaithful_model(p_unfaithful)
-    scm = AdditiveNoiseModel(10, graph_generator, noise_generator, mechanism, context)
+    scm = AdditiveNoiseModel(1000, graph_generator, noise_generator, mechanism, context)
 
-    _, adjacency = scm.sample() # sampling creates the unfaithful adjacency
+    _, adjacency = scm.sample()  # sampling creates the unfaithful adjacency
     unfaithful_adj = scm.scm_context.unfaithful_adjacency
-    assert np.allclose(adjacency, unfaithful_adj, 0.00001)
+    assert np.allclose(adjacency, unfaithful_adj, 0.0005)
 
 
 ###################### Test confounded model ######################
@@ -72,9 +121,11 @@ def test_given_p_confounded_when_generating_graphs_then_rate_of_confounded_pairs
 
     # sum_confounded_pairs = 0
     for _ in range(10):
-        scm = AdditiveNoiseModel(10, graph_generator, noise_generator, mechanism, context)
+        scm = AdditiveNoiseModel(
+            10, graph_generator, noise_generator, mechanism, context
+        )
 
-        _, _ = scm.sample() # sampling creates the confounded adjacency
+        _, _ = scm.sample()  # sampling creates the confounded adjacency
         confounded_adj = scm.scm_context.confounded_adjacency
         confounders_matrix = confounded_adj[num_nodes:, num_nodes:]
         n_direct_confounders = 0
@@ -98,7 +149,7 @@ def test_given_p_confounded_0_then_confounders_matrix_empty():
     context = SCMContext()
     context.confounded_model(p_confounder)
     scm = AdditiveNoiseModel(10, graph_generator, noise_generator, mechanism, context)
-    _, _ = scm.sample() # sampling creates the confounded adjacency
+    _, _ = scm.sample()  # sampling creates the confounded adjacency
     confounded_adj = scm.scm_context.confounded_adjacency
     assert np.sum(confounded_adj[:, :num_nodes]) == 0
 

--- a/causally/tests/test_utils.py
+++ b/causally/tests/test_utils.py
@@ -1,6 +1,6 @@
 import numpy as np
 from numpy.typing import NDArray
-from causally.utils.graph import topological_order, find_moral_colliders, is_a_collider
+from causally.utils.graph import topological_order, find_moral_colliders
 from causally.graph.random_graph import ErdosRenyi
 
 

--- a/causally/utils/graph.py
+++ b/causally/utils/graph.py
@@ -54,21 +54,21 @@ def topological_order(adjacency: np.array):
 
 
 # * For unfaithful generation *
-def is_a_collider(A: np.array, p1: int, p2: int, c: int):
+def is_a_moral_collider(A: np.array, p1: int, p2: int, c: int):
     """
     Parameters
     ----------
     A : np.array
-        Adj. matrix with potential collider
+        Adj. matrix with potential moral collider
     p1 : int
-        First parent of the potential collider
+        First parent of the potential moral collider
     p2 : int
-        Second parent of the potential collider
+        Second parent of the potential moral collider
     c : int
-        Head of the potential collider
+        Head of the potential moral collider
     """
-    # Check p1 -> c and p2 --> c
-    collider_struct = A[p1, c] == 1 and A[p2, c] == 1
+    # Check p1 -> c and p2 -> c and p1 -> p2
+    collider_struct = A[p1, c] == 1 and A[p2, c] == 1 and A[p1, p2] == 1
     return collider_struct
 
 

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -13,6 +13,7 @@ Classes for generation of random graphs.
    GaussianRandomPartition
    ErdosRenyi
    BarabasiAlbert
+   CustomGraph
 
 
 Causal mechanisms

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -10,16 +10,16 @@ Classes for generation of random graphs.
 .. autosummary::
    :toctree: generated/
    
-   GaussianRandomPartition
    ErdosRenyi
    BarabasiAlbert
+   GaussianRandomPartition
    CustomGraph
 
 
 Causal mechanisms
 -----------------
 
-Causally predefines linear and nonlinear causal mechanisms for the definition of structural equations.
+``causally`` predefines linear and nonlinear causal mechanisms for the definition of structural equations.
 
 .. currentmodule:: causally.scm.causal_mechanism
 .. autosummary::
@@ -49,8 +49,8 @@ Classes for random noise generation according to different parametric and nonpar
 
 Structural causal models
 ------------------------
-Causally implements linear, additive nonlinear, postnonliner structural causal models.
-Additionally, it allows data generation from SCMs with linear and nonlinear structural
+``causally`` implements linear, additive nonlinear, and post-nonlinear structural causal models.
+Additionally, it allows data generation from SCMs with mixed linear and nonlinear structural
 equations.
 
 .. currentmodule:: causally.scm.scm
@@ -67,10 +67,10 @@ equations.
 Challenging assumptions
 -----------------------
 
-Causally allows specifying challenging modeling assumptions on the SCM such as presence of
+``causally`` allows specifying challenging modeling assumptions on the SCM such as presence of
 latent confounders, unfaithfulness of the data distribution, presence of measurement errors
-and time structure. Assumptions are specified through an instance of the SCMContext class,
-which acts as a container of the SCM modeling assumptions.
+and autoregressive effects. Assumptions are specified through an instance of the ``SCMContext``
+class, which serves as a container of the SCM modeling assumptions.
 
 .. currentmodule:: causally.scm.context
 .. autosummary::

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -15,7 +15,7 @@ how to :ref:`install <installation>`.
 
 .. note::
 
-   This project is under active development.
+   Notebooks with examples will be added soon. Stay tuned!
 
 Cite
 ----


### PR DESCRIPTION
Upscalign the code for unfaithful data generation to graphs with more than three nodes. Unfaithfulness of the distribution is achieved through hard-coded path canceling. 
The previous implementation of unfaithful data generation was suitable for three nodes only.