### PR TITLE
Fix time lag index

### DIFF
--- a/causally/scm/scm_property.py
+++ b/causally/scm/scm_property.py
@@ -287,6 +287,6 @@ class _AutoregressiveMixin:
         linear_coeffs = np.random.uniform(weight_a, weight_b, (order,))
         for t in range(order, len(X)):
             for k in range(order):
-                X[t] += linear_coeffs[k] * X[t - k]
+                X[t] += linear_coeffs[k] * X[t-k-1]
 
         return X


### PR DESCRIPTION
In `causally/scm/scm_property.py`, in the function `add_time_lag` of the `_AutoregressiveMixin` class, the number of autoregressive steps was one unit smaller than the user request (e.g. if the user set the parameter `order=1`, this corresponded to the absence of lagged effects, as if `order=0`). This PR fix such issue.