### PR TITLE
Fix issue on the topological order function

### DIFF
--- a/causally/utils/graph.py
+++ b/causally/utils/graph.py
@@ -43,7 +43,7 @@ def topological_order(adjacency: np.array):
     mask = np.zeros((num_nodes))
     for _ in range(num_nodes):
         children_per_node = (
-            adjacency.sum(axis=1) + mask
+            adjacency.sum(axis=1) + mask - adjacency[:,order].sum(axis=1)
         )  # adjacency[i, j] = 1 --> i parent of j
         leaf = np.argmin(children_per_node)  # find leaf as node with no children
         mask[leaf] += float("inf")  # select node only once


### PR DESCRIPTION
There is a bug in the topological order function, which can cause some weird behaviour when sampling from the SCM.

https://github.com/francescomontagna/causally/blob/bbe0c2fce939cf3f784abfd09cee0f7a991641e1/causally/utils/graph.py#L33-L53

When iterating through, the nodes marked as leaf are not removed from the children set of the remaining nodes. The function hence returns a sort according to increasing number of children, which is not always a topological sort. Here is an example of a chain graph, 0->1->2->3->4:

```
>>> from causally.utils import graph as graph_utils 
>>> import numpy as np
>>> adj = np.triu(np.tril(np.ones((5,5)),-1),-1).T
>>> print(adj)
[[0. 1. 0. 0. 0.]
 [0. 0. 1. 0. 0.]
 [0. 0. 0. 1. 0.]
 [0. 0. 0. 0. 1.]
 [0. 0. 0. 0. 0.]]
>>> print(graph_utils.topological_order(adj))
[3, 2, 1, 0, 4]
```

The function correctly identifies 4 as a leaf, but since all other nodes have exactly one child, np.argmin breaks ties by selecting the smallest index, and so 0 is identified as the next leaf. The following fix on L46 solves the problem:

```
children_per_node = (
            adjacency.sum(axis=1) + mask - adjacency[:,order].sum(axis=1)
        )
```
 which removes children that are already in the order.
 
 ```
 print(graph_utils.topological_order_(adj))
[0, 1, 2, 3, 4]
```